### PR TITLE
Fix: upgrade Go base image to 1.25.7-alpine (stdlib CVEs)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM --platform=$BUILDPLATFORM golang:1.21-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.7-alpine AS builder
 
 ARG VERSION_ARG="0.0"
 ARG TARGETOS TARGETARCH


### PR DESCRIPTION
A security scan reported **6 HIGH** vulnerabilities in the produced binary (`utk.bin`), attributed to the **Go standard library (stdlib)**.

**Change**

Updated the builder base image in the Dockerfile from `golang:1.21-alpine` to `golang:1.25.7-alpine` to pull in patched stdlib fixes.

**Vulnerabilities referenced by the report**

- CVE-2024-34156
- CVE-2025-47907
- CVE-2025-58183
- CVE-2025-61726
- CVE-2025-61728
- CVE-2025-61729
